### PR TITLE
Allow disabling linting

### DIFF
--- a/index.js
+++ b/index.js
@@ -30,7 +30,7 @@ module.exports = {
     let project = this.project
     let ui = this.ui
 
-    if (type === 'templates' || type === 'addon') {
+    if (this.options.enabled === false || type === 'templates' || type === 'addon') {
       return undefined
     }
 


### PR DESCRIPTION
This will check the enabled flag in standard's options (if defined in `ember-cli-build.js`) and skip linting if set to false

Example:
```
  var app = new EmberApp(defaults, {
    standard: { //options for ember-cli-standard
      enabled: false
    },
```